### PR TITLE
Remove unused imports from agent and client modules

### DIFF
--- a/app/agents/cart_agent.py
+++ b/app/agents/cart_agent.py
@@ -1,11 +1,22 @@
-from agents import Agent, Runner, function_tool
+from agents import Agent, Runner
+from typing import Any, Dict, List
+
 from ..core.config import settings
-from ..tools.cart_tools import add_to_cart, update_cart, remove_from_cart, get_cart, clear_cart
-from ..tools.product_tools import get_product_info, get_product_by_id, check_product_availability, rag_product_search
-from ..prompts.cart_agent import CART_AGENT_PROMPT
 from ..core.hooks import CustomAgentHooks
-from typing import List, Dict, Any
-import asyncio
+from ..prompts.cart_agent import CART_AGENT_PROMPT
+from ..tools.cart_tools import (
+    add_to_cart,
+    clear_cart,
+    get_cart,
+    remove_from_cart,
+    update_cart,
+)
+from ..tools.product_tools import (
+    check_product_availability,
+    get_product_by_id,
+    get_product_info,
+    rag_product_search,
+)
 import json
 
 class CartAgentWrapper:

--- a/app/agents/checkout_agent.py
+++ b/app/agents/checkout_agent.py
@@ -1,16 +1,23 @@
-from agents import Agent, Runner, function_tool
-from ..core.config import settings
-from ..tools.cart_tools import (
-    get_cart, create_order, get_order_info, 
-    get_payment_info, get_my_orders
-)
-from ..tools.product_tools import get_product_by_id, check_product_availability, rag_product_search
-from ..prompts.checkout_agent import CHECKOUT_AGENT_PROMPT
-from ..core.hooks import CustomAgentHooks
+from agents import Agent, Runner
+from typing import Any, Dict, List
+
 from ..client.spring_client import spring_boot_client
-from typing import List, Dict, Any, Optional
+from ..core.config import settings
+from ..core.hooks import CustomAgentHooks
+from ..prompts.checkout_agent import CHECKOUT_AGENT_PROMPT
+from ..tools.cart_tools import (
+    create_order,
+    get_cart,
+    get_my_orders,
+    get_order_info,
+    get_payment_info,
+)
+from ..tools.product_tools import (
+    check_product_availability,
+    get_product_by_id,
+    rag_product_search,
+)
 import json
-import asyncio
 
 class CheckoutAgentWrapper:
     """

--- a/app/agents/manager_agent.py
+++ b/app/agents/manager_agent.py
@@ -1,15 +1,15 @@
-from agents import Agent, Runner, function_tool
-from ..core.config import settings
-from ..tools.manager_tools import get_assistant_info
-from ..prompts.manager_agent import MANAGER_AGENT_PROMPT
-from .product_agent import product_agent
-from .cart_agent import cart_agent
-from .shop_agent import shop_agent
-from .checkout_agent import checkout_agent
-from ..core.hooks import CustomAgentHooks
+from agents import Agent, Runner
+from typing import Any, Dict, List
+
 from ..client.spring_client import spring_boot_client
-from typing import List, Dict, Any, Optional
-import asyncio
+from ..core.config import settings
+from ..core.hooks import CustomAgentHooks
+from ..prompts.manager_agent import MANAGER_AGENT_PROMPT
+from ..tools.manager_tools import get_assistant_info
+from .cart_agent import cart_agent
+from .checkout_agent import checkout_agent
+from .product_agent import product_agent
+from .shop_agent import shop_agent
 
 class ManagerAgentWrapper:
     """

--- a/app/agents/product_agent.py
+++ b/app/agents/product_agent.py
@@ -1,10 +1,16 @@
-from agents import Agent, Runner, function_tool
-from ..core.config import settings
-from ..tools.product_tools import get_product_by_id, rag_product_search, check_product_availability, find_products_by_price_range
-from ..prompts.product_agent import PRODUCT_AGENT_PROMPT
+from agents import Agent, Runner
+from typing import Any, Dict, List
+
 from ..client.spring_client import spring_boot_client
+from ..core.config import settings
 from ..core.hooks import CustomAgentHooks
-from typing import List, Dict, Any, Optional
+from ..prompts.product_agent import PRODUCT_AGENT_PROMPT
+from ..tools.product_tools import (
+    check_product_availability,
+    find_products_by_price_range,
+    get_product_by_id,
+    rag_product_search,
+)
 import json
 
 class ProductAgentWrapper:

--- a/app/agents/shop_agent.py
+++ b/app/agents/shop_agent.py
@@ -1,10 +1,18 @@
-from agents import Agent, Runner, function_tool
-from ..core.config import settings
-from ..tools.shop_tools import get_shop_info, get_shipping_info, get_return_policy, get_contact_info, get_user_orders, get_order_details
-from ..prompts.shop_agent import SHOP_AGENT_PROMPT
+from agents import Agent, Runner
+from typing import Any, Dict, List
+
 from ..client.spring_client import spring_boot_client
+from ..core.config import settings
 from ..core.hooks import CustomAgentHooks
-from typing import List, Dict, Any, Optional
+from ..prompts.shop_agent import SHOP_AGENT_PROMPT
+from ..tools.shop_tools import (
+    get_contact_info,
+    get_order_details,
+    get_return_policy,
+    get_shipping_info,
+    get_shop_info,
+    get_user_orders,
+)
 
 class ShopAgentWrapper:
     """

--- a/app/client/spring_client.py
+++ b/app/client/spring_client.py
@@ -1,7 +1,7 @@
+from typing import Any, Dict, List, Optional
+
 import requests
-import random
-import json
-from typing import Dict, List, Any, Optional
+
 from ..core.config import settings
 
 class SpringBootClient:


### PR DESCRIPTION
## Summary
- prune unused imports across agents and client modules
- tidy import ordering and ensure files end with newline

## Testing
- `python -m py_compile app/agents/*.py app/client/*.py`
- `flake8 app/agents app/client` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1bbbee50833088fbaca334cffb46