### PR TITLE
Add centralized memory manager with event dedup support

### DIFF
--- a/app/agents/cart_agent.py
+++ b/app/agents/cart_agent.py
@@ -18,6 +18,7 @@ from ..tools.product_tools import (
     rag_product_search,
 )
 import json
+from ..memory.memory_manager import MemoryManager
 
 class CartAgentWrapper:
     """
@@ -184,17 +185,7 @@ class CartAgentWrapper:
         spring_boot_client.update_auth_token(auth_token)
         
         # Kết hợp lịch sử hội thoại với tin nhắn hiện tại
-        combined_message = message
-        if conversation_history and len(conversation_history) > 0:
-            # Lấy tối đa 5 tin nhắn gần nhất
-            recent_history = conversation_history[-5:] if len(conversation_history) > 5 else conversation_history
-            
-            history_text = ""
-            for msg in recent_history:
-                role = "Người dùng" if msg["role"] == "user" else "Trợ lý"
-                history_text += f"{role}: {msg['content']}\n"
-            
-            combined_message = f"Lịch sử hội thoại gần đây:\n{history_text}\nNgười dùng hiện tại: {message}"
+        combined_message = MemoryManager.build_prompt(message, conversation_history)
         
         # Sử dụng Runner từ OpenAI Agents SDK để xử lý tin nhắn đã kết hợp
         result = await Runner.run(self.agent, combined_message)

--- a/app/agents/checkout_agent.py
+++ b/app/agents/checkout_agent.py
@@ -18,6 +18,7 @@ from ..tools.product_tools import (
     rag_product_search,
 )
 import json
+from ..memory.memory_manager import MemoryManager
 
 class CheckoutAgentWrapper:
     """
@@ -143,17 +144,7 @@ class CheckoutAgentWrapper:
             }
         
         # Kết hợp lịch sử hội thoại với tin nhắn hiện tại
-        combined_message = message
-        if conversation_history and len(conversation_history) > 0:
-            # Lấy tối đa 5 tin nhắn gần nhất
-            recent_history = conversation_history[-5:] if len(conversation_history) > 5 else conversation_history
-            
-            history_text = ""
-            for msg in recent_history:
-                role = "Người dùng" if msg["role"] == "user" else "Trợ lý"
-                history_text += f"{role}: {msg['content']}\n"
-            
-            combined_message = f"Lịch sử hội thoại gần đây:\n{history_text}\nNgười dùng hiện tại: {message}"
+        combined_message = MemoryManager.build_prompt(message, conversation_history)
         
         # Sử dụng Runner để xử lý tin nhắn đã kết hợp
         result = await Runner.run(self.agent, combined_message)

--- a/app/agents/manager_agent.py
+++ b/app/agents/manager_agent.py
@@ -10,6 +10,7 @@ from .cart_agent import cart_agent
 from .checkout_agent import checkout_agent
 from .product_agent import product_agent
 from .shop_agent import shop_agent
+from ..memory.memory_manager import MemoryManager
 
 class ManagerAgentWrapper:
     """
@@ -197,17 +198,7 @@ class ManagerAgentWrapper:
         # Nhưng để đảm bảo, vẫn sử dụng Manager Agent để xử lý
         
         # Kết hợp lịch sử hội thoại với tin nhắn hiện tại
-        combined_message = message
-        if conversation_history and len(conversation_history) > 0:
-            # Lấy tối đa 5 tin nhắn gần nhất
-            recent_history = conversation_history[-5:] if len(conversation_history) > 5 else conversation_history
-            
-            history_text = ""
-            for msg in recent_history:
-                role = "Người dùng" if msg["role"] == "user" else "Trợ lý"
-                history_text += f"{role}: {msg['content']}\n"
-            
-            combined_message = f"Lịch sử hội thoại gần đây:\n{history_text}\nNgười dùng hiện tại: {message}"
+        combined_message = MemoryManager.build_prompt(message, conversation_history)
         
         result = await Runner.run(self.agent, combined_message)
         

--- a/app/agents/product_agent.py
+++ b/app/agents/product_agent.py
@@ -12,6 +12,7 @@ from ..tools.product_tools import (
     rag_product_search,
 )
 import json
+from ..memory.memory_manager import MemoryManager
 
 class ProductAgentWrapper:
     """
@@ -143,17 +144,7 @@ class ProductAgentWrapper:
         spring_boot_client.update_auth_token(auth_token)
         
         # Kết hợp lịch sử hội thoại với tin nhắn hiện tại
-        combined_message = message
-        if conversation_history and len(conversation_history) > 0:
-            # Lấy tối đa 5 tin nhắn gần nhất
-            recent_history = conversation_history[-5:] if len(conversation_history) > 5 else conversation_history
-            
-            history_text = ""
-            for msg in recent_history:
-                role = "Người dùng" if msg["role"] == "user" else "Trợ lý"
-                history_text += f"{role}: {msg['content']}\n"
-            
-            combined_message = f"Lịch sử hội thoại gần đây:\n{history_text}\nNgười dùng hiện tại: {message}"
+        combined_message = MemoryManager.build_prompt(message, conversation_history)
         
         # Sử dụng Runner với chuỗi tin nhắn đã kết hợp
         result = await Runner.run(self.agent, combined_message)

--- a/app/agents/shop_agent.py
+++ b/app/agents/shop_agent.py
@@ -13,6 +13,7 @@ from ..tools.shop_tools import (
     get_shop_info,
     get_user_orders,
 )
+from ..memory.memory_manager import MemoryManager
 
 class ShopAgentWrapper:
     """
@@ -86,17 +87,7 @@ class ShopAgentWrapper:
         spring_boot_client.update_auth_token(auth_token)
         
         # Kết hợp lịch sử hội thoại với tin nhắn hiện tại
-        combined_message = message
-        if conversation_history and len(conversation_history) > 0:
-            # Lấy tối đa 5 tin nhắn gần nhất
-            recent_history = conversation_history[-5:] if len(conversation_history) > 5 else conversation_history
-            
-            history_text = ""
-            for msg in recent_history:
-                role = "Người dùng" if msg["role"] == "user" else "Trợ lý"
-                history_text += f"{role}: {msg['content']}\n"
-            
-            combined_message = f"Lịch sử hội thoại gần đây:\n{history_text}\nNgười dùng hiện tại: {message}"
+        combined_message = MemoryManager.build_prompt(message, conversation_history)
         
         # Sử dụng Runner với tin nhắn đã kết hợp
         result = await Runner.run(self.agent, combined_message)

--- a/app/db/services.py
+++ b/app/db/services.py
@@ -78,6 +78,14 @@ class ConversationService:
             .limit(limit)
         return self.session.exec(query).all()
 
+    def get_last_message(self, conversation_id: str) -> Optional[Message]:
+        """Get the most recent message in a conversation."""
+        query = select(Message) \
+            .where(Message.conversation_id == conversation_id) \
+            .order_by(Message.created_at.desc()) \
+            .limit(1)
+        return self.session.exec(query).first()
+
     def get_all_messages(self, conversation_id: str) -> List[Message]:
         """Get all messages from a conversation, ordered by created_at."""
         query = select(Message) \

--- a/app/memory/memory_manager.py
+++ b/app/memory/memory_manager.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Callable, DefaultDict, Dict, List, Optional
+import hashlib
+
+
+class MemoryManager:
+    """Utility class to manage conversation memory with deduplication and events."""
+
+    def __init__(self, conversation_service):
+        self.conversation_service = conversation_service
+        self._subscribers: DefaultDict[str, List[Callable[[Dict[str, Any]], None]]] = defaultdict(list)
+
+    # ------------------------------------------------------------------
+    # Event system
+    # ------------------------------------------------------------------
+    def subscribe(self, event_type: str, handler: Callable[[Dict[str, Any]], None]) -> None:
+        """Register a handler for a specific event type."""
+        self._subscribers[event_type].append(handler)
+
+    def _emit(self, event_type: str, payload: Dict[str, Any]) -> None:
+        for handler in self._subscribers.get(event_type, []):
+            handler(payload)
+
+    # ------------------------------------------------------------------
+    # Message helpers
+    # ------------------------------------------------------------------
+    def add_message(
+        self,
+        conversation_id: str,
+        role: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ):
+        """Add a message with simple deduplication and optional event emission."""
+        last = self.conversation_service.get_last_message(conversation_id)
+        if last:
+            last_hash = hashlib.sha256((last.role + last.content).encode()).hexdigest()
+            new_hash = hashlib.sha256((role + content).encode()).hexdigest()
+            if last_hash == new_hash:
+                return last
+
+        message = self.conversation_service.add_message(
+            conversation_id=conversation_id,
+            role=role,
+            content=content,
+            metadata=metadata,
+        )
+
+        event_type = metadata.get("event_type") if metadata else None
+        if event_type:
+            self._emit(
+                event_type,
+                {
+                    "conversation_id": conversation_id,
+                    "role": role,
+                    "content": content,
+                    "metadata": metadata,
+                },
+            )
+        return message
+
+    def get_recent_history(self, conversation_id: str, limit: int = 5) -> List[Dict[str, Any]]:
+        """Fetch recent conversation history."""
+        return self.conversation_service.get_conversation_history(conversation_id, limit)
+
+    @staticmethod
+    def build_prompt(message: str, conversation_history: List[Dict[str, Any]]) -> str:
+        """Combine message with recent history to create a prompt."""
+        if not conversation_history:
+            return message
+
+        history_text = ""
+        for msg in conversation_history[-5:]:
+            role = "Người dùng" if msg["role"] == "user" else "Trợ lý"
+            history_text += f"{role}: {msg['content']}\n"
+
+        return f"Lịch sử hội thoại gần đây:\n{history_text}\nNgười dùng hiện tại: {message}"


### PR DESCRIPTION
## Summary
- Introduce `MemoryManager` to centralize conversation history, add deduplication, and emit events
- Add `get_last_message` in `ConversationService` and integrate `MemoryManager` into chat endpoint
- Update agents to build prompts via `MemoryManager` instead of custom history logic

## Testing
- `/usr/bin/python3 -m py_compile app/memory/memory_manager.py app/db/services.py app/api/endpoints.py app/agents/cart_agent.py app/agents/product_agent.py app/agents/checkout_agent.py app/agents/manager_agent.py app/agents/shop_agent.py`
- `/usr/bin/python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1e742c3483308749b0d7d332ac33